### PR TITLE
Improve search error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# poe_wiki_api
+# Path of Exile Weapon Search
+
+This small Django project provides a simple search page that queries the community PoE wiki via its Cargo API. Results are filtered by weapon class, attack speed and DPS.
+
+## Development setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install django requests
+```
+
+2. Run the development server:
+
+```bash
+python manage.py runserver
+```
+
+3. Open `http://localhost:8000/` in your browser.
+
+A network connection is required for the search results to load because the server fetches data from `poewiki.net`.

--- a/weapons/templates/weapons/search.html
+++ b/weapons/templates/weapons/search.html
@@ -53,6 +53,9 @@
   </form>
   
   <!-- Results Table -->
+  {% if error %}
+    <div class="alert alert-danger" role="alert">{{ error }}</div>
+  {% endif %}
   {% if results %}
     <h2 class="mb-3">Results</h2>
     <table class="table table-striped table-hover">

--- a/weapons/views.py
+++ b/weapons/views.py
@@ -49,21 +49,36 @@ def search_weapons(request):
         # Finalize URL with format=json for direct JSON output
         api_url = f"{base_url}{join}{fields}{where_clause}&format=json"
         
-        # Fetch data from the Wiki API
-        response = requests.get(api_url)
-        data = response.json()  # Parse JSON response
+        # Fetch data from the Wiki API. A custom User-Agent prevents requests from
+        # being blocked by the wiki and makes debugging easier.
+        headers = {
+            "User-Agent": "poe-wiki-api/1.0 (+https://example.com)"
+        }
         results = []
-        for entry in data.get("cargoquery", []):
-            item = entry["title"]
-            # Prepare each result (convert numeric strings to float/int as needed)
-            results.append({
-                "name": item.get("name"),
-                "class": item.get("class"),
-                "attack_speed": item.get("attack_speed"),
-                "physical_dps": item.get("physical_dps_range_average"),
-                "elemental_dps": item.get("elemental_dps_range_average"),
-                "total_dps": item.get("dps_range_average"),
-            })
+        try:
+            response = requests.get(api_url, headers=headers, timeout=10)
+            response.raise_for_status()
+            data = response.json()  # Parse JSON response
+            for entry in data.get("cargoquery", []):
+                item = entry["title"]
+                # Prepare each result (convert numeric strings to float/int as
+                # needed)
+                results.append({
+                    "name": item.get("name"),
+                    "class": item.get("class"),
+                    "attack_speed": item.get("attack_speed"),
+                    "physical_dps": item.get(
+                        "physical_dps_range_average"
+                    ),
+                    "elemental_dps": item.get(
+                        "elemental_dps_range_average"
+                    ),
+                    "total_dps": item.get("dps_range_average"),
+                })
+        except (requests.RequestException, ValueError) as exc:
+            # If the API call fails or returns invalid JSON, keep results empty
+            # and attach the error message so the template can show feedback.
+            context["error"] = str(exc)
         context["results"] = results
         context["filters"] = {   # include current filters to refill form, if needed
             "weapon_class": weapon_class or "",


### PR DESCRIPTION
## Summary
- add setup instructions to README
- handle errors from the wiki API and use a custom User-Agent
- show an alert in the template when the API call fails

## Testing
- `python3 manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684040292a3c8332840d0255eaf9e894